### PR TITLE
Fix string formatting error

### DIFF
--- a/audiolab/pysndfile/_sndfile.pyx
+++ b/audiolab/pysndfile/_sndfile.pyx
@@ -741,7 +741,7 @@ broken)"""
         elif input.dtype == np.short:
             res = self.write_frames_short(input, nframes)
         else:
-            raise Exception("type of input &s not understood" % str(input.dtype))
+            raise Exception("type of input %s not understood" % str(input.dtype))
 
         if not(res == nframes):
             raise IOError("write %d frames, expected to write %d"


### PR DESCRIPTION
Throws "TypeError: not all arguments converted during string formatting" because format string is invalid.